### PR TITLE
Bump to version 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-upgrade-shims",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Culture Amp's Elm 0.18-to-0.19 API shims",
   "repository": "https://github.com/cultureamp/elm-upgrade-shims.git",
   "author": "Louis Quinnell <louis.quinnell@cultureamp.com>",


### PR DESCRIPTION
Now that the new URL shim is in master, we can update the version number.